### PR TITLE
Fix incorrect alignment

### DIFF
--- a/ui/usfm-grammar.css
+++ b/ui/usfm-grammar.css
@@ -286,7 +286,7 @@ body {
     }
 
     .box2-content {
-      float: right;
+      /* float: right; */
       height: 645px;
 
     }
@@ -329,7 +329,7 @@ body {
     }
 
     .box2-content {
-      float: right;
+      /* float: right; */
       height: 740px;
 
     }


### PR DESCRIPTION
### Background
The content of the parsed USFM looked squished to the right for me in both Firefox Nightly 90.0a1 and Safari 14.0.

### Resolution
Removed a seemingly unwanted `float: right`.